### PR TITLE
fix column in PacientData,fix realtimeinfer result

### DIFF
--- a/Backend_Deployment/src/Microsoft.Solutions.PatientHub.RealtimeInferenceService/Model/PatientData.cs
+++ b/Backend_Deployment/src/Microsoft.Solutions.PatientHub.RealtimeInferenceService/Model/PatientData.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Solutions.PatientHub.RealtimeInferenceService.Model
     public class PatientData
     {
         public string race { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
         public string gender { get; set; }
         public string age { get; set; }
         public string weight { get; set; }


### PR DESCRIPTION
This merge fix erro in machine learn response, realinference now pass 52 columns for machine learn in azure.
- Before realinference pass only 50  columns.
- Add columns 'FirstName' and 'LastName' on file Model/PatientData.cs.
`C#
 public string FirstName { get; set; }
 public string LastName { get; set; }
`